### PR TITLE
Requirements and dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - scipy>=1.1
 - pyzmq>=17.1.2
 - coloredlogs>=10.0
-- tables>=3.4.4
+- pytables>=3.4.4
 - pytest>=4.0.2
 - sphinx>=1.8
 - sphinx_rtd_theme
@@ -18,3 +18,5 @@ dependencies:
   - pylsl==1.10.5
   - python-dotenv==0.10.1
   - python-osc==1.7.0
+  - git+https://github.com/timeflux/timeflux	
+  - git+https://github.com/timeflux/timeflux_example

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,5 @@ dependencies:
   - pylsl==1.10.5
   - python-dotenv==0.10.1
   - python-osc==1.7.0
-  - git+https://github.com/timeflux/timeflux	
+  - git+https://github.com/timeflux/timeflux
   - git+https://github.com/timeflux/timeflux_example

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,11 @@ name: timeflux
 dependencies:
 - python>=3.6.7
 - networkx>=2.1
-- PyYAML>=3.13
+- pyyaml>=3.13
 - numpy>=1.15
 - pandas>=0.23.4
 - xarray>=0.11
+- bottleneck
 - scipy>=1.1
 - pyzmq>=17.1.2
 - coloredlogs>=10.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,15 +2,14 @@ name: timeflux
 dependencies:
 - python>=3.6.7
 - networkx>=2.1
-- pyyaml>=3.13
+- PyYAML>=3.13
 - numpy>=1.15
 - pandas>=0.23.4
 - xarray>=0.11
-- bottleneck
 - scipy>=1.1
 - pyzmq>=17.1.2
 - coloredlogs>=10.0
-- pytables>=3.4.4
+- tables>=3.4.4
 - pytest>=4.0.2
 - sphinx>=1.8
 - sphinx_rtd_theme
@@ -19,5 +18,3 @@ dependencies:
   - pylsl==1.10.5
   - python-dotenv==0.10.1
   - python-osc==1.7.0
-  - git+https://github.com/timeflux/timeflux
-  - git+https://github.com/timeflux/timeflux_example

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML>=3.13
 numpy>=1.15
 pandas>=0.23.4
 xarray>=0.11
+bottleneck
 scipy>=1.1
 pyzmq>=17.1.2
 coloredlogs>=10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sphinx>=1.8
 sphinx_rtd_theme
 pylsl==1.10.5
 python-osc==1.7.0
+python-dotenv==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+networkx>=2.1
+PyYAML>=3.13
+numpy>=1.15
+pandas>=0.23.4
+xarray>=0.11
+scipy>=1.1
+pyzmq>=17.1.2
+coloredlogs>=10.0
+tables>=3.4.4
+Cython>=0.29.6
+pytest>=4.0.2
+sphinx>=1.8
+sphinx_rtd_theme
+pylsl==1.10.5
+python-osc==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ sphinx_rtd_theme
 pylsl==1.10.5
 python-osc==1.7.0
 python-dotenv==0.10.1
+#git+https://github.com/timeflux/timeflux	
+#git+https://github.com/timeflux/timeflux_example

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ dependencies = [
     'numpy',
     'pandas',
     'xarray',
+    'bottleneck',
     'scipy',
     'pyzmq',
     'coloredlogs',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,20 @@ with open('README.md', 'rb') as f:
 with open('timeflux/__init__.py') as f:
     VERSION = re.search('^__version__\s*=\s*\'(.*)\'', f.read(), re.M).group(1)
 
+dependencies = [
+    'networkx',
+    'PyYAML',
+    'numpy',
+    'pandas',
+    'xarray',
+    'scipy',
+    'pyzmq',
+    'coloredlogs',
+    'tables',
+    'pylsl',
+    'python-osc',
+]
+
 setup(
     name='Timeflux',
     packages=find_packages(),
@@ -21,4 +35,5 @@ setup(
     author='Pierre Clisson',
     author_email='contact@timeflux.io',
     url='https://timeflux.io',
+    install_requires=dependencies,
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ dependencies = [
     'tables',
     'pylsl',
     'python-osc',
+    'python-dotenv',
 ]
 
 setup(


### PR DESCRIPTION
With these changes, I propose to fix two problems:

1. Doing a `pip install <timeflux dir>` should always install all dependencies. This is achieved by defining the `install_requires` packages on the `setup.py` script
2. Providing a `requirements.txt` file that works for non-conda users (i.e. me).

I've also removed dependencies that are not used anywhere, or dependencies that were named incorrectly.