### PR TITLE
WIP for logging restructure

### DIFF
--- a/timeflux/__init__.py
+++ b/timeflux/__init__.py
@@ -1,13 +1,3 @@
 """ Timeflux """
 
 __version__ = '0.1.0'
-
-import logging
-import coloredlogs
-
-FORMAT = '%(asctime)s    %(levelname)-10s %(module)-12s %(process)-8s %(processName)-16s %(message)s'
-LEVEL_STYLES = {'debug': {'color': 'white'}, 'info': {'color': 'cyan'}, 'warning': {'color': 'yellow'}, 'error': {'color': 'red'}, 'critical': {'color': 'magenta'}}
-FIELD_STYLES = {'asctime': {'color': 'blue'}, 'levelname': {'color': 'black', 'bright': True}, 'processName': {'color': 'green'}}
-
-logging.basicConfig(format=FORMAT, level=logging.DEBUG)
-coloredlogs.install(fmt=FORMAT, level='DEBUG', milliseconds=True, level_styles=LEVEL_STYLES, field_styles=FIELD_STYLES)

--- a/timeflux/timeflux.py
+++ b/timeflux/timeflux.py
@@ -22,6 +22,17 @@ def init_logs():
                     'processName': {'color': 'green'}}
     date_format = "%(asctime)s %(levelname)-10s %(module)-12s %(process)-8s %(processName)-16s %(message)s"
 
+    # On windows, the colors will not work unless we initialize the console with colorama
+    if sys.platform.startswith('win'):
+        try:
+            import colorama
+            colorama.init()
+        except ImportError:
+            # On windows, without colorama, do not use the colors
+            level_styles = {}
+            field_styles = {}
+
+
     logging_config = {
         'version': 1,
         'disable_existing_loggers': False,
@@ -56,11 +67,11 @@ def init_logs():
 
 
 def main():
-    LOGGER.info('Timeflux %s' % __version__)
     sys.path.append(os.getcwd())
     args = _args()
     load_dotenv(args.env)
     init_logs()
+    LOGGER.info('Timeflux %s',  __version__)
     signal.signal(signal.SIGINT, _interrupt)
     _run_hook('pre')
     try:

--- a/timeflux/timeflux.py
+++ b/timeflux/timeflux.py
@@ -16,14 +16,15 @@ PID = os.getpid()
 
 
 def init_logs():
-    LEVEL_STYLES = {'debug': {'color': 'white'}, 'info': {'color': 'cyan'}, 'warning': {'color': 'yellow'},
+    level_styles = {'debug': {'color': 'white'}, 'info': {'color': 'cyan'}, 'warning': {'color': 'yellow'},
                     'error': {'color': 'red'}, 'critical': {'color': 'magenta'}}
-    FIELD_STYLES = {'asctime': {'color': 'blue'}, 'levelname': {'color': 'black', 'bright': True},
+    field_styles = {'asctime': {'color': 'blue'}, 'levelname': {'color': 'black', 'bright': True},
                     'processName': {'color': 'green'}}
+    date_format = "%(asctime)s %(levelname)-10s %(module)-12s %(process)-8s %(processName)-16s %(message)s"
 
     logging_config = {
         'version': 1,
-        'disable_existing_loggers': True,  # set True to suppress existing loggers from other modules
+        'disable_existing_loggers': False,
         'root': {
             'level': 'INFO',
             'handlers': ['console'],
@@ -34,21 +35,20 @@ def init_logs():
             },
         },
         'formatters': {
-            'colored_console': {'()': 'coloredlogs.ColoredFormatter',
-                                'format': "%(asctime)s    %(levelname)-10s %(module)-12s %(process)-8s %(processName)-16s %(message)s",
-                                'datefmt': '%Y-%m-%d %H:%M:%S,%f',
-                                'field_styles': FIELD_STYLES,
-                                'level_styles': LEVEL_STYLES},
-            'format_for_file': {
-                'format': "%(asctime)s :: %(levelname)s :: %(funcName)s in %(filename)s (l:%(lineno)d) :: %(message)s",
-                'datefmt': '%Y-%m-%d %H:%M:%S'},
+            'colored_console': {
+                '()': 'coloredlogs.ColoredFormatter',
+                'format': date_format,
+                'datefmt': '%Y-%m-%d %H:%M:%S,%f',
+                'field_styles': field_styles,
+                'level_styles': level_styles,
+            },
         },
         'handlers': {
             'console': {
                 'level': 'DEBUG',
                 'class': 'logging.StreamHandler',
                 'formatter': 'colored_console',
-                'stream': 'ext://sys.stdout'
+                'stream': 'ext://sys.stdout',
             },
         }
     }
@@ -56,11 +56,11 @@ def init_logs():
 
 
 def main():
-    init_logs()
     LOGGER.info('Timeflux %s' % __version__)
     sys.path.append(os.getcwd())
     args = _args()
     load_dotenv(args.env)
+    init_logs()
     signal.signal(signal.SIGINT, _interrupt)
     _run_hook('pre')
     try:


### PR DESCRIPTION
Hey @mesca, with this commit, I am working with @bertrandlalo to have a more refined approach to logs. Instead of using coloredlogs to config the logs, we use a `logging.config.dictConfig` call that uses the coloredlogs formatter, so that the logs are exactly as before. With this configuration, we can set timeflux to debug, and everything else to info.

Ideally, we should change all `logging.xxx` for `logger.xxx` with a `logger = logging.getLogger(__name__)` so that the changes are propagated correctly, but we wanted to make sure that we all agree on this approach first.

If you agree, @bertrandlalo and me can do the related changes, but *do not merge this yet*.

Maybe related:

* Maybe the order of the initialization on the main should change, considering that you are using load_env at one point.