### PR TITLE
Fix epoch

### DIFF
--- a/test/test_node_epoch.py
+++ b/test/test_node_epoch.py
@@ -2,11 +2,11 @@
 
 import pandas as pd
 import helpers
-from pandas.testing import assert_frame_equal
 from timeflux.nodes.epoch import Epoch
 
 data = helpers.DummyData()
-node = Epoch(event_trigger='test')
+node = Epoch(event_trigger='test', before=.2, after=.6)
+
 
 def test_no_epoch():
     # Send enough data for an epoch, but no event
@@ -37,19 +37,30 @@ def test_receive_epoch():
     }
     expected_data = pd.DataFrame(
         [
-            [0.176528, 0.220486, 0.186438, 0.779584, 0.350125],
-            [0.057843, 0.969103, 0.883786, 0.927752, 0.994908],
-            [0.173895, 0.396242, 0.758238, 0.696021, 0.153896],
-            [0.815833, 0.224441, 0.223818, 0.536974, 0.592940],
-            [0.580086, 0.091487, 0.877461, 0.265600, 0.129515],
-            [0.888748, 0.955651, 0.862128, 0.809516, 0.655242],
-            [0.550857, 0.086987, 0.408453, 0.372689, 0.259754],
-            [0.723420, 0.495876, 0.081046, 0.220183, 0.683259]
+           [0.176528, 0.220486, 0.186438, 0.779584, 0.350125],
+           [0.057843, 0.969103, 0.883786, 0.927752, 0.994908],
+           [0.173895, 0.396242, 0.758238, 0.696021, 0.153896],
+           [0.815833, 0.224441, 0.223818, 0.536974, 0.59294 ],
+           [0.580086, 0.091487, 0.877461, 0.2656  , 0.129515],
+           [0.888748, 0.955651, 0.862128, 0.809516, 0.655242],
+           [0.057843, 0.969103, 0.883786, 0.927752, 0.994908],
+           [0.173895, 0.396242, 0.758238, 0.696021, 0.153896],
+           [0.815833, 0.224441, 0.223818, 0.536974, 0.59294 ],
+           [0.580086, 0.091487, 0.877461, 0.2656  , 0.129515],
+           [0.888748, 0.955651, 0.862128, 0.809516, 0.655242],
+           [0.550857, 0.086987, 0.408453, 0.372689, 0.259754],
+           [0.72342 , 0.495876, 0.081046, 0.220183, 0.683259]
         ],
         [
             pd.Timestamp('2018-01-01 00:00:01.897912291'),
             pd.Timestamp('2018-01-01 00:00:02.001118529'),
             pd.Timestamp('2018-01-01 00:00:02.096394939'),
+            pd.Timestamp('2018-01-01 00:00:02.197921447'),
+            pd.Timestamp('2018-01-01 00:00:02.298663618'),
+            pd.Timestamp('2018-01-01 00:00:02.399560700'),
+            pd.Timestamp('2018-01-01 00:00:02.001118529'),
+            pd.Timestamp('2018-01-01 00:00:02.096394939'),
+
             pd.Timestamp('2018-01-01 00:00:02.197921447'),
             pd.Timestamp('2018-01-01 00:00:02.298663618'),
             pd.Timestamp('2018-01-01 00:00:02.399560700'),
@@ -107,21 +118,73 @@ def test_multiple_triggers():
 
 def test_unsynced_event():
     # The epoch must be fetched even if the trigger time does not match exactly
+    node = Epoch(event_trigger='test', before=.1, after=.2)
+    data.reset()
+
     node.clear()
     node.i.data = data.next(20)
-    time = pd.Timestamp('2018-01-01 00:00:07.100')
+    time = pd.Timestamp('2018-01-01 00:00:00.55')
     event = pd.DataFrame([['test', 'foobar']], [time], columns=['label', 'data'])
     node.i_events.data = event
     node.update()
+
     expected_indices = pd.DatetimeIndex([
-        pd.Timestamp('2018-01-01T00:00:06.904868869'),
-        pd.Timestamp('2018-01-01T00:00:07.002722448'),
-        pd.Timestamp('2018-01-01T00:00:07.096987157'),
-        pd.Timestamp('2018-01-01T00:00:07.195055221'),
-        pd.Timestamp('2018-01-01T00:00:07.303154614'),
-        pd.Timestamp('2018-01-01T00:00:07.402068573'),
-        pd.Timestamp('2018-01-01T00:00:07.502290072'),
-        pd.Timestamp('2018-01-01T00:00:07.602712703'),
-        pd.Timestamp('2018-01-01T00:00:07.695740447')
+        pd.Timestamp('2018-01-01 00:00:00.496559945'),
+        pd.Timestamp('2018-01-01 00:00:00.595580836'),
+        pd.Timestamp('2018-01-01 00:00:00.703661761'),
+        pd.Timestamp('2018-01-01 00:00:00.496559945'),
+        pd.Timestamp('2018-01-01 00:00:00.595580836'),
+        pd.Timestamp('2018-01-01 00:00:00.703661761'),
     ])
     pd.testing.assert_index_equal(node.o.data.index, expected_indices)
+
+
+def test_receives_event_before_data():
+    # receives event before data
+    # NB: this use case can also happen if before<0
+    data.reset()
+    node = Epoch(event_trigger='test', before=0, after=.6)
+    node.clear()
+    node.i.data = data.next(5)
+    time = data._data.index[6]  # Sync event right after last sample
+    event = pd.DataFrame([['test', 'foobar']], [time], columns=['label', 'data'])  # Generate a trigger event
+    node.i_events.data = event
+    node.update()
+    node.i_events.data = None
+    node.i.data = data.next(10)
+    node.update()
+    expected_data = pd.DataFrame(
+        [
+            [0.037008, 0.59627, 0.230009, 0.120567, 0.076953],
+            [0.696289, 0.339875, 0.724767, 0.065356, 0.31529],
+            [0.539491, 0.790723, 0.318753, 0.625891, 0.885978],
+            [0.615863, 0.232959, 0.024401, 0.870099, 0.021269],
+            [0.874702, 0.528937, 0.939068, 0.798783, 0.997934],
+            [0.350712, 0.767188, 0.401931, 0.479876, 0.627505]
+        ],
+        [
+            pd.Timestamp('2018-01-01 00:00:00.595580836'),
+            pd.Timestamp('2018-01-01 00:00:00.703661761'),
+            pd.Timestamp('2018-01-01 00:00:00.801011149'),
+            pd.Timestamp('2018-01-01 00:00:00.902080726'),
+            pd.Timestamp('2018-01-01 00:00:00.995205845'),
+            pd.Timestamp('2018-01-01 00:00:01.104699099'),
+        ]
+    )
+    expected_meta = {'epoch': {'onset': pd.Timestamp('2018-01-01 00:00:00.595580836'), 'context': 'foobar'}}
+    assert node.o.meta == expected_meta
+    pd.testing.assert_frame_equal(node.o.data, expected_data)
+
+def test_empty_epoch():
+    # no data received in the epoch
+    data = helpers.DummyData(rate=.1)
+    node = Epoch(event_trigger='test', before=-1, after=1)
+    node.clear()
+    node.i.data = data.next(5)
+    time = pd.Timestamp("2018-01-01 00:00:10.450714306")  # Sync event to second sample
+    event = pd.DataFrame([['test', 'foobar']], [time], columns=['label', 'data'])  # Generate a trigger event
+    node.i_events.data = event
+    node.update()
+    expected_meta = {'epoch': {'onset': pd.Timestamp('2018-01-01 00:00:10.450714306'), 'context': 'foobar'}}
+    assert node.o.meta == expected_meta
+    assert node.o.data.empty

--- a/timeflux/__init__.py
+++ b/timeflux/__init__.py
@@ -1,13 +1,3 @@
 """ Timeflux """
 
 __version__ = '0.1.0'
-
-import logging
-import coloredlogs
-
-FORMAT = '%(asctime)s    %(levelname)-10s %(module)-12s %(process)-8s %(processName)-16s %(message)s'
-LEVEL_STYLES = {'debug': {'color': 'white'}, 'info': {'color': 'cyan'}, 'warning': {'color': 'yellow'}, 'error': {'color': 'red'}, 'critical': {'color': 'magenta'}}
-FIELD_STYLES = {'asctime': {'color': 'blue'}, 'levelname': {'color': 'black', 'bright': True}, 'processName': {'color': 'green'}}
-
-logging.basicConfig(format=FORMAT, level=logging.DEBUG)
-coloredlogs.install(fmt=FORMAT, level='DEBUG', milliseconds=True, level_styles=LEVEL_STYLES, field_styles=FIELD_STYLES)

--- a/timeflux/core/node.py
+++ b/timeflux/core/node.py
@@ -1,10 +1,20 @@
 """Node base class."""
 
 import re
+import logging
 from abc import ABC, abstractmethod
 from timeflux.core.io import Port
 
 class Node(ABC):
+
+
+    def __new__(cls, *args, **kwargs):
+        """Create instance and initialize the logger."""
+
+        instance = super().__new__(cls)
+        instance.logger = logging.getLogger(__name__ + '.' + cls.__name__)
+        return instance
+
 
     def __init__(self):
         """Instantiate the node."""
@@ -14,14 +24,11 @@ class Node(ABC):
 
     def __getattr__(self, name):
         """Create input and output ports on the fly.
-
         Args:
             name (string): The name of the port, prefixed with `i_` (input) or `o_` (output).
                            Default ports are also allowed (`i` or `o`).
-
         Returns:
             Port: The newly created port.
-
         """
 
         if name == 'i' or name.startswith('i_') or name == 'o' or name.startswith('o_'):
@@ -33,21 +40,16 @@ class Node(ABC):
 
     def iterate(self, name='*'):
         """Iterate through ports.
-
         If ``name`` ends with the globbing character (`*`), the generator iterates through all existing
         ports matching that pattern. Otherwise, only one port is returned. If it does not already exist,
         it is automatically created.
-
         Args:
             name (string): The matching pattern.
-
         Yields:
             (tupple): A tupple containing:
-
             * name (`string`): The full port name.
             * suffix (`string`): The part of the name matching the globbing character.
             * port (`Port`): The port object.
-
         """
 
         if not self.ports: self.ports = {}
@@ -63,11 +65,9 @@ class Node(ABC):
 
     def clear(self):
         """Reset all ports.
-
         It is assumed that numbered ports (i.e. those with a name ending with an underscore followed by numbers)
         are temporary and must be completely removed. All other ports are simply emptied to avoid the cost of
         reinstanciating a new `Port` object before each update.
-
         """
 
         if not self._re_dynamic_port:

--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -84,13 +84,11 @@ class Epoch(Node):
                 if not self.i.data.empty:
                     complete = 0
                     for epoch in self._epochs:
-                        # low = epoch['data'].index[-1]
                         low = epoch['meta']['onset'] - self._before
                         high = epoch['meta']['onset'] + self._after
                         last = self.i.data.index[-1]
                         # Append
                         mask = (self.i.data.index >= low) & (self.i.data.index <= high)
-                        # mask = (self.i.data.index > low) & (self.i.data.index <= high)
                         epoch['data'] = epoch['data'].append(self.i.data[mask])
                         # Send if we have enough data
                         if last >= high:

--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -64,6 +64,7 @@ class Epoch(Node):
                         # Start a new epoch
                         low = index - self._before
                         high = index + self._after
+                        # check that last accumulated timestamp is
                         self._epochs.append({
                             'data': self._buffer[low:high],
                             'meta': {
@@ -83,11 +84,13 @@ class Epoch(Node):
                 if not self.i.data.empty:
                     complete = 0
                     for epoch in self._epochs:
-                        low = epoch['data'].index[-1]
+                        # low = epoch['data'].index[-1]
+                        low = epoch['meta']['onset'] - self._before
                         high = epoch['meta']['onset'] + self._after
                         last = self.i.data.index[-1]
                         # Append
-                        mask = (self.i.data.index > low) & (self.i.data.index <= high)
+                        mask = (self.i.data.index >= low) & (self.i.data.index <= high)
+                        # mask = (self.i.data.index > low) & (self.i.data.index <= high)
                         epoch['data'] = epoch['data'].append(self.i.data[mask])
                         # Send if we have enough data
                         if last >= high:

--- a/timeflux/timeflux.py
+++ b/timeflux/timeflux.py
@@ -3,8 +3,7 @@
 import signal
 import sys
 import os
-import logging
-from logging.config import dictConfig
+import logging, logging.handlers
 from argparse import ArgumentParser
 from importlib import import_module
 from dotenv import load_dotenv
@@ -14,54 +13,13 @@ from timeflux.core.manager import Manager
 LOGGER = logging.getLogger(__name__)
 PID = os.getpid()
 
-
-def init_logs():
-    LEVEL_STYLES = {'debug': {'color': 'white'}, 'info': {'color': 'cyan'}, 'warning': {'color': 'yellow'},
-                    'error': {'color': 'red'}, 'critical': {'color': 'magenta'}}
-    FIELD_STYLES = {'asctime': {'color': 'blue'}, 'levelname': {'color': 'black', 'bright': True},
-                    'processName': {'color': 'green'}}
-
-    logging_config = {
-        'version': 1,
-        'disable_existing_loggers': True,  # set True to suppress existing loggers from other modules
-        'root': {
-            'level': 'INFO',
-            'handlers': ['console'],
-        },
-        'loggers': {
-            'timeflux': {
-                'level': os.getenv('TIMEFLUX_LOG_LEVEL', 'DEBUG'),
-            },
-        },
-        'formatters': {
-            'colored_console': {'()': 'coloredlogs.ColoredFormatter',
-                                'format': "%(asctime)s    %(levelname)-10s %(module)-12s %(process)-8s %(processName)-16s %(message)s",
-                                'datefmt': '%Y-%m-%d %H:%M:%S,%f',
-                                'field_styles': FIELD_STYLES,
-                                'level_styles': LEVEL_STYLES},
-            'format_for_file': {
-                'format': "%(asctime)s :: %(levelname)s :: %(funcName)s in %(filename)s (l:%(lineno)d) :: %(message)s",
-                'datefmt': '%Y-%m-%d %H:%M:%S'},
-        },
-        'handlers': {
-            'console': {
-                'level': 'DEBUG',
-                'class': 'logging.StreamHandler',
-                'formatter': 'colored_console',
-                'stream': 'ext://sys.stdout'
-            },
-        }
-    }
-    dictConfig(logging_config)
-
-
 def main():
-    init_logs()
     LOGGER.info('Timeflux %s' % __version__)
     sys.path.append(os.getcwd())
     args = _args()
     load_dotenv(args.env)
     signal.signal(signal.SIGINT, _interrupt)
+    _log_init()
     _run_hook('pre')
     try:
         Manager(args.app).run()
@@ -91,6 +49,12 @@ def _terminate():
         LOGGER.info('Terminated')
         logging.shutdown()
     sys.exit(0)
+
+def _log_init():
+    try:
+        logging.getLogger().setLevel(os.getenv('TIMEFLUX_LOG_LEVEL'))
+    except Exception:
+        pass
 
 def _run_hook(name):
     module = os.getenv('TIMEFLUX_HOOK_' + name.upper())


### PR DESCRIPTION
**Handle case where there is not enough data** 
- Two changes in node epoch
https://github.com/timeflux/timeflux/blob/master/timeflux/nodes/epoch.py#L65: 
instead of considering the last timestamp of the epoch as 'low', consider onset-before, so that if there is not enough data, you keep accumulating. 
https://github.com/timeflux/timeflux/blob/master/timeflux/nodes/epoch.py#L90 change < in <= to handle the new definition of 'low'. 
- Correction of 2 units test. 
- Add 2 units test for cases 
     - the onset of the event arrives after the data
     - the epoch is empty