### PR TITLE
Add directory create on hdf5 save node

### DIFF
--- a/timeflux/nodes/hdf5.py
+++ b/timeflux/nodes/hdf5.py
@@ -132,6 +132,7 @@ class Save(Node):
             see: http://pandas.pydata.org/pandas-docs/stable/io.html#string-columns
 
         """
+        os.makedirs(path, exist_ok=True)
         fname = os.path.join(path, time.strftime('%Y%m%d-%H%M%S.hdf5', time.gmtime()))
         logging.info('Saving to %s', fname)
         self._store = pd.HDFStore(fname, complib=complib, complevel=complevel)


### PR DESCRIPTION
Here is a simple fix: when the hdf5 save node takes its path parameter and it does not exist, the node fails. I propose that the hdf5 save node should create the directory when it does not exist.