### PR TITLE
Add metadata handling on HDF5 save node

### DIFF
--- a/timeflux/nodes/hdf5.py
+++ b/timeflux/nodes/hdf5.py
@@ -150,7 +150,7 @@ class Save(Node):
                     # Note: not none and not an empty dict, because this operation
                     #       overwrites previous metadata and an empty dict would
                     #       just remove any previous change
-                    self._store.get_node(key)._v_attrs['timeflux_meta'] = port.meta
+                    self._store.get_node(key)._v_attrs['meta'] = port.meta
 
 
     def terminate(self):

--- a/timeflux/nodes/hdf5.py
+++ b/timeflux/nodes/hdf5.py
@@ -150,7 +150,6 @@ class Save(Node):
                     # Note: not none and not an empty dict, because this operation
                     #       overwrites previous metadata and an empty dict would
                     #       just remove any previous change
-                    self.logger.info('Saving meta for %s', key)
                     self._store.get_node(key)._v_attrs['timeflux_meta'] = port.meta
 
 

--- a/timeflux/nodes/hdf5.py
+++ b/timeflux/nodes/hdf5.py
@@ -141,10 +141,18 @@ class Save(Node):
     def update(self):
         if self.ports is not None:
             for name, port in self.ports.items():
+                if not name.startswith('i'):
+                    continue
+                key = '/' + name[2:].replace('_', '/')
                 if port.data is not None:
-                    if name.startswith('i'):
-                        key = '/' + name[2:].replace('_', '/')
-                        self._store.append(key, port.data, min_itemsize=self.min_itemsize)
+                    self._store.append(key, port.data, min_itemsize=self.min_itemsize)
+                if port.meta is not None and port.meta:
+                    # Note: not none and not an empty dict, because this operation
+                    #       overwrites previous metadata and an empty dict would
+                    #       just remove any previous change
+                    self.logger.info('Saving meta for %s', key)
+                    self._store.get_node(key)._v_attrs['timeflux_meta'] = port.meta
+
 
     def terminate(self):
         self._store.close()


### PR DESCRIPTION
I am adding a small improvement to the HDF5 save node: when an input has metadata, it saves it into the HDF5 attributes (meant for metadata).

This is a quick fix for Raph to have something for the NFB demo, but can be improved as needed if you have any particular comment or improvement direction.