### PR TITLE
Remove nodevalueerror

### DIFF
--- a/test/test_node_epoch.py
+++ b/test/test_node_epoch.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from timeflux.core.branch import Branch
-from timeflux.core.exceptions import NodeValueError
+from timeflux.core.exceptions import WorkerInterrupt
 from timeflux.helpers import testing as helpers
 from timeflux.nodes.epoch import Epoch
 
@@ -300,5 +300,5 @@ def test_to_xarray():
         ], columns=['label', 'data'])
     converted_epoch.set_port('epoch', port_id='i_events', data=event)
 
-    with pytest.raises(NodeValueError):
+    with pytest.raises(WorkerInterrupt):
         converted_epoch.update()

--- a/timeflux/core/exceptions.py
+++ b/timeflux/core/exceptions.py
@@ -37,11 +37,3 @@ class WorkerInterrupt(TimefluxException):
     def __init__(self, message='Interrupting', *args):
         self.message = message
         super().__init__(message, *args)
-
-
-class NodeValueError(TimefluxException):
-    """Raised when a node received invalid data"""
-
-    def __init__(self, message, *args):
-        self.message = message
-        super().__init__(message, *args)

--- a/timeflux/nodes/accumulate.py
+++ b/timeflux/nodes/accumulate.py
@@ -40,7 +40,7 @@ class AppendDataFrame(Node):
         gate_status = self.i.meta.get('gate_status')
 
         # When we have not received data, there is nothing to do
-        if self.i.ready():
+        if not self.i.ready():
             return
         # At this point, we are sure that we have some data to process
 
@@ -93,7 +93,7 @@ class AppendDataArray(Node):
         gate_status = self.i.meta.get('gate_status')
 
         # When we have not received data, there is nothing to do
-        if self.i.ready():
+        if not self.i.ready():
             return
         # At this point, we are sure that we have some data to process
 

--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from timeflux.core.node import Node
-from timeflux.core.exceptions import NodeValueError
+from timeflux.core.exceptions import WorkerInterrupt
 
 
 class Epoch(Node):
@@ -162,7 +162,7 @@ class EpochToXArray(Node):
                 self._set_times()
                 self._rate = self._rate or port.meta.get('rate')
                 if self._rate is None:
-                    raise NodeValueError('Rate should be specified either in '
+                    raise WorkerInterrupt('Rate should be specified either in '
                                          'the parameters or in the port meta. ')
                 self._ready = True
 
@@ -208,7 +208,7 @@ class EpochToXArray(Node):
             return False
         if port.data.shape[0] != self._num_times:
             if self._reporting == 'error':
-                raise NodeValueError(f'Received an epoch with {port.data.shape[0]} '
+                raise WorkerInterrupt(f'Received an epoch with {port.data.shape[0]} '
                                      f'samples instead of {self._num_times}.')
             elif self._reporting == 'warn':
                 self.logger.warning(f'Received an epoch with {port.data.shape[0]} '


### PR DESCRIPTION
Remove exception NodeValueError from core exceptions, replace it by 'WorkerInterrupt'. 