### PR TITLE
Fix dejitter unit test 

### DIFF
--- a/test/test_node_dejitter.py
+++ b/test/test_node_dejitter.py
@@ -106,5 +106,6 @@ def test_data_not_monotonic():
     data = dummy_data_not_monotonic
     node = Interpolate(rate=rate)
     looper = Looper(data, node)
-    with pytest.raises(WorkerInterrupt):
-        _, _ = looper.run(chunk_size=8)
+    o_data, _ = looper.run(chunk_size=8)
+    assert o_data.index.is_monotonic
+    assert np.unique(np.diff(o_data.index))[0] == np.timedelta64(100000000, 'ns')

--- a/timeflux/nodes/dejitter.py
+++ b/timeflux/nodes/dejitter.py
@@ -112,12 +112,15 @@ class Interpolate(Node):
     def _drop_duplicates(self, data):
         return data.loc[~data.index.duplicated(keep='first')]
 
+    def _make_monotonic(self, data):
+        return data[np.diff(pd.Index([self._last_datetime]).append(data.index)) / np.timedelta64(1, 's') > 0]
     def _interpolate(self):
         # interpolate current chunk
         self._buffer = self._buffer.append(self.i.data, sort=True)  # append last sample be able to interpolate
 
         if not self._buffer.index.is_monotonic:
             self.logger.warning('Data index should be strictly monotonic')
+            self._buffer = self._make_monotonic(self._buffer)
 
         data_to_interpolate = self._buffer.append(pd.DataFrame(index=self._times),
                                                   sort=True)


### PR DESCRIPTION
Warning logging (and drop decreasing index) instead of worker
interruption when data is not monotonic in node Interpolate