### PR TITLE
Conda package

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,64 @@
+# Note that this file is in a separate directory. If I put in on the root
+# directory, the resulting package will include all other files instead of
+# the source files only.
+
+{% set name = "timeflux" %}
+{% set version = "0.4" %}
+{% set tag = "v0.4" %}
+
+package:
+  name: "{{ name | lower }}"
+  version: "{{ version }}"
+
+source:
+  git_url:  https://github.com/timeflux/timeflux.git
+  git_tag: "{{ tag }}"
+
+requirements:
+  build:
+    - python>=3.7,<3.8
+    - setuptools
+
+  run:
+    - python>=3.7,<3.8
+    - numpy
+    - scipy
+    - scikit-learn
+    - pandas
+    - matplotlib
+    - seaborn
+    - h5py
+    - pyyaml
+    - pytables
+    - statsmodels
+    - cvxopt
+    - deprecated
+    - pyxdf
+
+test:
+  # We will re-activate this later
+  #  source_files:
+  #    - tests/*
+  #  requires:
+  #    - pytest
+  #    - pytest-mock
+  #  commands:
+  #    - py.test tests
+  imports:
+    - timeflux
+    - timeflux.core
+    - timeflux.nodes
+    - timeflux.helpers
+
+build:
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+extra:
+  maintainers:
+    - contact@timeflux.io
+
+about:
+  home: https://timeflux.io
+  summary: "Timeflux: acquisition and real-time processing of biosignals."
+  license_file: LICENSE

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,26 +21,32 @@ requirements:
 
   run:
     - python>=3.7,<3.8
-    - numpy
-    - scipy
-    - scikit-learn
-    - pandas
-    - matplotlib
-    - seaborn
-    - h5py
-    - pyyaml
-    - pytables
-    - statsmodels
-    - cvxopt
-    - deprecated
-    - pyxdf
+    - networkx>=2.4
+    - pyyaml>=5.1
+    - numpy>=1.17
+    - pandas>=0.25
+    - xarray>=0.14
+    - bottleneck>=1.3
+    - scipy>=1.3
+    - pyzmq>=18.1
+    - coloredlogs>=10.0
+    - pytables>=3.6
+    - jsonschema>=3.0
+    # - python-dotenv>=0.10  # MISSING due to being in conda-forge
+    - pytest>=5.3
+    - sphinx>=2.2
+    - sphinx_rtd_theme>=0.4
+    - python-graphviz>=0.13
+    # MISSING DUE TO BEING IN PIP:
+    # - pylsl>=1.13.1
+    # - python-osc>=1.7.0
 
 test:
   # We will re-activate this later
   #  source_files:
   #    - tests/*
-  #  requires:
-  #    - pytest
+  requires:
+    - pytest>=5.3
   #    - pytest-mock
   #  commands:
   #    - py.test tests

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
 
   run:
     - python>=3.7,<3.8
+    # NOTE: In my opinion, dependencies should be top-version limited. In case a new
+    #       library version breaks timeflux.
     - networkx>=2.4
     - pyyaml>=5.1
     - numpy>=1.17
@@ -32,17 +34,17 @@ requirements:
     - coloredlogs>=10.0
     - pytables>=3.6
     - jsonschema>=3.0
-    # - python-dotenv>=0.10  # MISSING due to being in conda-forge
-    - pytest>=5.3
-    - sphinx>=2.2
-    - sphinx_rtd_theme>=0.4
     - python-graphviz>=0.13
-    # MISSING DUE TO BEING IN PIP:
+    # NOTE: due to this dependency, which is only available on conda-forge,
+    #       the build procedure is a bit more complicated (it needs to add the
+    #       conda-forge channel)
+    - python-dotenv>=0.10
+    # REMOVED dependencies, because they are not on conda, only installable through pip:
     # - pylsl>=1.13.1
     # - python-osc>=1.7.0
 
 test:
-  # We will re-activate this later
+  # TODO: Re-activate and test this later
   #  source_files:
   #    - tests/*
   requires:
@@ -66,5 +68,7 @@ extra:
 
 about:
   home: https://timeflux.io
-  summary: "Timeflux: acquisition and real-time processing of biosignals."
-  license_file: LICENSE
+  summary: Acquisition and real-time processing of biosignals
+  license: MIT
+  license_family: MIT
+  doc_url: https://doc.timeflux.io/latest/

--- a/doc/general/conda.rst
+++ b/doc/general/conda.rst
@@ -41,3 +41,30 @@ Folow this procedure to create a conda package for timeflux:
 
      $ anaconda login
      $ anaconda upload --user bob /Users/bob/miniconda3/envs/build-env/conda-bld/noarch/timeflux-X.Y.Z-py_0.tar.bz2
+
+
+Notes
+-----
+
+The ``pylsl`` and ``python-osc`` packages work correctly only through pip packages,
+and the ``python-dotenv`` package is not in the default channels, which still
+complicates the installation approach. Here is a environment file that should
+work:
+
+.. code-block:: yaml
+
+   name: my-env
+   channels:
+     - defaults
+     - conda-forge
+     # - some-channel-name  # << This will be the channel where timeflux is stored.
+                            #    For the moment, it will most likely be timeflux.
+                            #    In the future, it may already be in conda-forge
+   dependencies:
+     - python
+     - timeflux
+     # optional, but recommended:
+     - pip
+     - pip:
+       - pylsl
+       - python-osc

--- a/doc/general/conda.rst
+++ b/doc/general/conda.rst
@@ -1,0 +1,43 @@
+Building a conda package
+========================
+
+Folow this procedure to create a conda package for timeflux:
+
+1. Create a build environment and add the required building packages:
+
+   .. code-block:: console
+
+    $ conda env create -n build-env python=3.7
+    $ conda activate build-env
+    $ conda install conda-build anaconda-client
+
+2. Modify the ``conda.recipe/meta.yaml`` file accordingly, in particular to
+   set the version number and which github tag will be used as a reference.
+
+3. Clone the timeflux package and build the package from its root directory.
+   You should get an output as follows:
+
+   .. code-block:: console
+
+    $ conda-build --channel conda-forge .
+    ...
+    TEST END: /Users/bob/miniconda3/envs/build-env/conda-bld/noarch/timeflux-X.Y.Z-py_0.tar.bz2
+    ####################################################################################
+    Resource usage summary:
+
+    Total time: 0:01:22.1
+    CPU usage: sys=0:00:00.1, user=0:00:00.2
+    Maximum memory usage observed: 22.3M
+    Total disk usage observed (not including envs): 3.4K
+
+
+    ####################################################################################
+    ...
+
+4. Upload the package. You will need an anaconda.org account and you will need
+   to log-in by command-line just before:
+
+   .. code-block:: console
+
+     $ anaconda login
+     $ anaconda upload --user bob /Users/bob/miniconda3/envs/build-env/conda-bld/noarch/timeflux-X.Y.Z-py_0.tar.bz2

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,6 +37,7 @@ Drivers for open and proprietary hardware (EEG, ECG, PPG, EDA, respiration, eye 
     general/about.rst
     general/concepts.rst
     general/getting_help.rst
+    general/conda.rst
 
 
 .. raw:: latex

--- a/timeflux/helpers/lsl.py
+++ b/timeflux/helpers/lsl.py
@@ -1,11 +1,21 @@
 """Enumerate LSL streams."""
 
-from pylsl import resolve_streams
+import logging
 
-def enumerate():
+logger = logging.getLogger(__name__)
+
+try:
+    from pylsl import resolve_streams
+except ModuleNotFoundError:
+    logger.exception('pylsl is not installed, you will encounter NameErrors '
+                     'unless you install pylsl')
+
+
+def enumerate_streams():
     streams = resolve_streams()
     for stream in streams:
         print(f'name: {stream.name()}, type: {stream.type()}, source_id: {stream.source_id()}')
 
+
 if __name__ == '__main__':
-    enumerate()
+    enumerate_streams()

--- a/timeflux/nodes/lsl.py
+++ b/timeflux/nodes/lsl.py
@@ -7,12 +7,26 @@
 
 """
 
-import pandas as pd
-import numpy as np
-import uuid
-from pylsl import StreamInfo, StreamOutlet, StreamInlet, resolve_stream, resolve_byprop, pylsl
+import logging
 from time import time
+import uuid
+
+import numpy as np
+import pandas as pd
+
 from timeflux.core.node import Node
+
+# Dynamically import lsl
+logger = logging.getLogger(__name__)
+try:
+    from pylsl import (
+        StreamInfo, StreamOutlet, StreamInlet,
+        resolve_stream, resolve_byprop, pylsl
+    )
+except ModuleNotFoundError:
+    logger.exception('pylsl is not installed, you will encounter NameErrors '
+                     'unless you install pylsl')
+
 
 class Send(Node):
 

--- a/timeflux/nodes/osc.py
+++ b/timeflux/nodes/osc.py
@@ -1,12 +1,21 @@
 """timeflux.nodes.osc: Simple OSC client and server"""
 
-import pandas as pd
+import logging
 from threading import Thread, Lock
-from pythonosc.dispatcher import Dispatcher
-from pythonosc.osc_server import BlockingOSCUDPServer
-from pythonosc.udp_client import SimpleUDPClient
+
 from timeflux.helpers.clock import now
 from timeflux.core.node import Node
+
+# Dynamically import osc
+logger = logging.getLogger(__name__)
+try:
+    from pythonosc.dispatcher import Dispatcher
+    from pythonosc.osc_server import BlockingOSCUDPServer
+    from pythonosc.udp_client import SimpleUDPClient
+except ModuleNotFoundError:
+    logger.exception('python-osc is not installed, you will encounter NameErrors '
+                     'unless you install python-osc')
+
 
 class Server(Node):
 


### PR DESCRIPTION
This is a conda recipe to create a timeflux conda package. A first step towards having an easier installation procedure.

I had to make a compromise and remove pylsl and python-osc from the dependencies because:

- pylsl does have a package on a user channel, but it does not work on windows
- python-osc has no conda package
- a conda package cannot handle pip packages, everything most be in conda

For this reason, I changed the imports so they are dynamic and show an error when a package is missing.

Another thing that is not included here is a conda-forge recipe. Let us first use this way and when it is tried and tested, we can follow the instructions to publish it on conda-forge (https://conda-forge.org/#add_recipe)
