### PR TITLE
Warn epoch monotonic

### DIFF
--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -60,7 +60,7 @@ class Epoch(Node):
                 low = index - self._before
                 high = index + self._after
                 if not self._buffer.index.is_monotonic:
-                    self.logger.warning(f"Index should be monotonic. Skipping epoch {row['data']}")
+                    self.logger.warning(f"Index should be monotonic. Skipping epoch {row['data']}.")
                     return
                 self._epochs.append({
                     'data': self._buffer[low:high],

--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -59,6 +59,9 @@ class Epoch(Node):
                 # Start a new epoch
                 low = index - self._before
                 high = index + self._after
+                if not self._buffer.index.is_monotonic:
+                    self.logger.warning(f"Index should be monotonic. Skipping epoch {row['data']}")
+                    return
                 self._epochs.append({
                     'data': self._buffer[low:high],
                     'meta': {


### PR DESCRIPTION
If epoch index is not monotonic [L63](https://github.com/timeflux/timeflux/blob/bb0c390aad629e4ad9a84696d6ecb298fe6638a2/timeflux/nodes/epoch.py#L63) will raise an Exception. Warning the user and returning as a safeguard from interruption. 
