### PR TITLE
Fix window

### DIFF
--- a/test/nodes/test_window.py
+++ b/test/nodes/test_window.py
@@ -78,7 +78,7 @@ def test_not_monotonic(data):
 
 
 def test_no_memory_leek(data):
-    # receive too much data, avoid memory leak by truncate buffer
+    # receive too much data, avoid memory leak by truncating buffer
     node = Window(length=1, step=.2)
     data.reset()
     node.i.data = data.next(30)

--- a/test/nodes/test_window.py
+++ b/test/nodes/test_window.py
@@ -75,3 +75,12 @@ def test_not_monotonic(data):
     not_monotonic.index = not_monotonic.index[:5].append([not_monotonic.index[3:-2]])
     node.i.data = not_monotonic
     node.update()
+
+
+def test_no_memory_leek(data):
+    # step lower than length
+    node = Window(length=1, step=.2)
+    data.reset()
+    node.i.data = data.next(30)
+    node.update()
+    assert len(node._buffer) == 8

--- a/test/nodes/test_window.py
+++ b/test/nodes/test_window.py
@@ -1,56 +1,77 @@
 """Tests for window.py"""
 
 import pandas as pd
+import pytest
 
 from timeflux.helpers import testing as helpers
 from timeflux.nodes.window import Window
 
-data = helpers.DummyData(jitter=0)
 
-rate = 10
-length = 1
-step = None
-node = Window(length=length, step=None)
+@pytest.fixture(scope="function")
+def data():
+    return helpers.DummyData(jitter=0)
 
 
-def test_not_enough_data():
+def check_parameters():
+    with pytest.raises(ValueError):
+        node = Window(length=1, step=2)
+
+
+def test_not_enough_data(data):
+    node = Window(length=1, step=None)
     # Not enough data to
     node.i.data = data.next(5)
     node.update()
     assert node.o.data == None
 
 
-def test_enough_data():
-    # Not enough data to
-    node.i.data = data.next(6)
+def test_enough_data(data):
+    # enough data to
+    node = Window(length=1, step=None)
+    node.i.data = data.next(11)
     node.update()
-    pd.testing.assert_frame_equal(node.o.data, data._data.iloc[1:11, :])
+    pd.testing.assert_frame_equal(node.o.data, data._data.iloc[0:10, :])
 
 
-def test_no_overlap():
+def test_no_overlap(data):
     # reset generator and node states
-    data.reset()
-    node.__init__(length=length, step=None)
-    node.clear()
+    node = Window(length=1, step=None)
     # Send enough data for an epoch, but no event
     node.i.data = data.next(11)
     node.update()
-    o1 = node.o.data.copy()
-    node.i.data = data.next(10)
+    o1 = node.o.data
+    node.clear()
+    node.i.data = data.next(11)
     node.update()
-    o2 = node.o.data.copy()
-    pd.testing.assert_frame_equal(o1.append(o2), data._data.iloc[1:21])
+    o2 = node.o.data
+    # assert continuity (no repeated samples)
+    pd.testing.assert_frame_equal(o1.append(o2), data._data.iloc[0:20])
+    # assert window length
+    assert len(o2) == 10
 
 
-def test_low_step():
+def test_low_step(data):
     # step lower than length
-    step = .2
-    node = Window(length=length, step=step)
+    node = Window(length=1, step=.2)
     data.reset()
     node.i.data = data.next(11)
     node.update()
     o1 = node.o.data
-    node.i.data = data.next(2)
+    node.clear()
+    node.i.data = data.next(3)
     node.update()
     o2 = node.o.data
-    assert (o2.index[0] - o1.index[0]).total_seconds() == step
+    # assert step size
+    assert (o2.index[0] - o1.index[0]).total_seconds() == 0.2
+    # assert window length
+    assert len(o2) == 10
+
+
+def test_not_monotonic(data):
+    # step lower than length
+    node = Window(length=1, step=.2)
+    data.reset()
+    not_monotonic = data.next(11)
+    not_monotonic.index = not_monotonic.index[:5].append([not_monotonic.index[3:-2]])
+    node.i.data = not_monotonic
+    node.update()

--- a/test/nodes/test_window.py
+++ b/test/nodes/test_window.py
@@ -13,20 +13,21 @@ def data():
 
 
 def check_parameters():
+    # step should be lower than window length
     with pytest.raises(ValueError):
         node = Window(length=1, step=2)
 
 
 def test_not_enough_data(data):
+    # not enough data to window
     node = Window(length=1, step=None)
-    # Not enough data to
     node.i.data = data.next(5)
     node.update()
     assert node.o.data == None
 
 
 def test_enough_data(data):
-    # enough data to
+    # receive enough data window
     node = Window(length=1, step=None)
     node.i.data = data.next(11)
     node.update()
@@ -34,9 +35,8 @@ def test_enough_data(data):
 
 
 def test_no_overlap(data):
-    # reset generator and node states
+    # test step equals length
     node = Window(length=1, step=None)
-    # Send enough data for an epoch, but no event
     node.i.data = data.next(11)
     node.update()
     o1 = node.o.data
@@ -68,7 +68,7 @@ def test_low_step(data):
 
 
 def test_not_monotonic(data):
-    # step lower than length
+    # receive data that is not monotonic
     node = Window(length=1, step=.2)
     data.reset()
     not_monotonic = data.next(11)
@@ -78,7 +78,7 @@ def test_not_monotonic(data):
 
 
 def test_no_memory_leek(data):
-    # step lower than length
+    # receive too much data, avoid memory leak by truncate buffer
     node = Window(length=1, step=.2)
     data.reset()
     node.i.data = data.next(30)

--- a/timeflux/nodes/window.py
+++ b/timeflux/nodes/window.py
@@ -16,33 +16,36 @@ class Window(Node):
                 If None (the default), the step will be set to the window duration.
                 If 0, the data will be sent as soon as it is available.
         """
-
-        if step is None: step = length
+        if step is None:
+            step = length
+        if step > length:
+            raise ValueError('Step of window should be smaller or equal to length. ')
         self._length = pd.Timedelta(seconds=length)
         self._step = pd.Timedelta(seconds=step)
         self._buffer = None
-        self._updated = pd.Timestamp(0)
 
     def update(self):
         # Return immediately if we don't have any data
         if not self.i.ready():
             return
+        # Sanity check
+        if not self.i.data.index.is_monotonic:
+            self.logger.warning('Window received data with not monotonic index.')
+
         # Append new data
         if self._buffer is None:
             self._buffer = self.i.data
         else:
             self._buffer = self._buffer.append(self.i.data)
-        # Time range
-        high = self._buffer.index[-1]
-        low = high - self._length
-        # Make sure we have enough data
-        if self._buffer.index[0] <= low:
-            # Step
-            if high - self._updated >= self._step:
-                # Clear old data
-                self._buffer = self._buffer[self._buffer.index > low]
-                # Remember the last time the buffer was updated
-                self._updated = high
-                # Output
-                self.o.data = self._buffer
-                self.o.meta = self.i.meta
+        # Calculate if we are ready to window the current buffer
+        low = self._buffer.index[0]
+        high = low + self._length
+        if self._buffer.index[-1] >= high:
+            self.o.data = self._buffer[self._buffer.index < high]
+            self.o.meta = self.o.meta
+            self._buffer = self._buffer[self._buffer.index >= low + self._step]
+
+        if not self._buffer.empty and (self._buffer.index[-1] - self._buffer.index[0]) > self._length:
+            self.logger.warning('This node is falling behind: it is receiving '
+                                'more data that it can generate. Verify the step size '
+                                'and the graph rate')

--- a/timeflux/nodes/window.py
+++ b/timeflux/nodes/window.py
@@ -12,7 +12,7 @@ class Window(Node):
 
         Args:
             length (float): The length of the window, in seconds.
-            step (float): The minimal sliding step, in seconds.
+            step (float|None): The minimal sliding step, in seconds.
                 If None (the default), the step will be set to the window duration.
                 If 0, the data will be sent as soon as it is available.
         """

--- a/timeflux/nodes/window.py
+++ b/timeflux/nodes/window.py
@@ -49,3 +49,5 @@ class Window(Node):
             self.logger.warning('This node is falling behind: it is receiving '
                                 'more data that it can generate. Verify the step size '
                                 'and the graph rate')
+            # truncate buffer to avoid memory leaks
+            self._buffer = self._buffer[self._buffer.index > self._buffer.index[-1] - self._length + self._step]


### PR DESCRIPTION
**Old way:** when the node received more data than window length, the older data
was lost.
**New way:** keep the last samples in the buffer and append it to the next chunk

Also, I added a few sanity checks, such as index monotonic and step <= =length 

**test**: Add fixture in the unit test, allowing them to be ran independently 