### PR TITLE
Fix/epoch

### DIFF
--- a/timeflux/estimators/transformers/shape.py
+++ b/timeflux/estimators/transformers/shape.py
@@ -3,15 +3,19 @@ from sklearn.base import BaseEstimator, TransformerMixin, ClassifierMixin
 
 
 class Expand(BaseEstimator, TransformerMixin):
-    def __init__(self, axis=0):
+    def __init__(self, axis=0, dimensions=3):
         self._axis = axis
+        self._dimensions = dimensions
 
     def fit(self, X, y=None):
         return self
 
     def transform(self, X):
         X = np.asarray(X)
-        return np.expand_dims(X, axis=self._axis)
+        if len(X.shape) < self._dimensions:
+            return np.expand_dims(X, axis=self._axis)
+        else:
+            return X
 
     def fit_transform(self, X, y=None):
         return self.fit(X).transform(X)

--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -59,22 +59,23 @@ class Epoch(Node):
                 # Start a new epoch
                 low = index - self._before
                 high = index + self._after
-                if not self._buffer.index.is_monotonic:
-                    self.logger.warning(
-                        f"Index should be monotonic. Skipping epoch {row['data']}."
+                if not self._buffer is not None:
+                    if not self._buffer.index.is_monotonic:
+                        self.logger.warning(
+                            f"Index should be monotonic. Skipping epoch {row['data']}."
+                        )
+                        return
+                    self._epochs.append(
+                        {
+                            "data": self._buffer[low:high],
+                            "meta": {
+                                "onset": index,
+                                "context": row["data"],
+                                "before": self._before.total_seconds(),
+                                "after": self._after.total_seconds(),
+                            },
+                        }
                     )
-                    return
-                self._epochs.append(
-                    {
-                        "data": self._buffer[low:high],
-                        "meta": {
-                            "onset": index,
-                            "context": row["data"],
-                            "before": self._before.total_seconds(),
-                            "after": self._after.total_seconds(),
-                        },
-                    }
-                )
 
         # Trim main buffer
         if self._buffer is not None:

--- a/timeflux/nodes/epoch.py
+++ b/timeflux/nodes/epoch.py
@@ -59,7 +59,7 @@ class Epoch(Node):
                 # Start a new epoch
                 low = index - self._before
                 high = index + self._after
-                if not self._buffer is not None:
+                if self._buffer is not None:
                     if not self._buffer.index.is_monotonic:
                         self.logger.warning(
                             f"Index should be monotonic. Skipping epoch {row['data']}."


### PR DESCRIPTION
- Fix on `nodes/epoch` : check that buffer is not None before checking index are monotonic
- Change on `estimators/transformers/shape.py` : expand dimension only when shape is 2D. Use case : for data epoched without an overlap, the training X will be of 3D but the testing X will be of 2D. Hence, we want to reshape only if necessary. 