### PR TITLE
Modified Estimator to match sklearn documentation + Added Cross-validated support

### DIFF
--- a/timeflux/estimators/transformers/shape.py
+++ b/timeflux/estimators/transformers/shape.py
@@ -4,13 +4,13 @@ from sklearn.base import BaseEstimator, TransformerMixin, ClassifierMixin
 
 class Transpose(BaseEstimator, TransformerMixin):
     def __init__(self, axes):
-        self._axes = axes
+        self.axes = axes
 
     def fit(self, X, y=None):
         return self
 
     def transform(self, X):
-        return np.transpose(X, self._axes)
+        return np.transpose(X, self.axes)
 
     def fit_transform(self, X, y=None):
         return self.fit(X).transform(X)
@@ -18,8 +18,8 @@ class Transpose(BaseEstimator, TransformerMixin):
 
 class Expand(BaseEstimator, TransformerMixin):
     def __init__(self, axis=0, dimensions=3):
-        self._axis = axis
-        self._dimensions = dimensions
+        self.axis = axis
+        self.dimensions = dimensions
 
     def fit(self, X, y=None):
         return self
@@ -27,7 +27,7 @@ class Expand(BaseEstimator, TransformerMixin):
     def transform(self, X):
         X = np.asarray(X)
         if len(X.shape) < self._dimensions:
-            return np.expand_dims(X, axis=self._axis)
+            return np.expand_dims(X, axis=self.axis)
         else:
             return X
 
@@ -37,7 +37,7 @@ class Expand(BaseEstimator, TransformerMixin):
 
 class Reduce(BaseEstimator, TransformerMixin):
     def __init__(self, axis=0):
-        self._axis = axis
+        self.axis = axis
 
     def fit(self, X, y=None):
         return self
@@ -46,7 +46,7 @@ class Reduce(BaseEstimator, TransformerMixin):
         X = np.asarray(X)
         if X.ndim < 3:
             return X
-        return np.squeeze(X, axis=self._axis)
+        return np.squeeze(X, axis=self.axis)
 
     def fit_transform(self, X, y=None):
         return self.fit(X).transform(X)

--- a/timeflux/estimators/transformers/shape.py
+++ b/timeflux/estimators/transformers/shape.py
@@ -27,7 +27,7 @@ class Expand(BaseEstimator, TransformerMixin):
     def transform(self, X):
         X = np.asarray(X)
         if len(X.shape) < self._dimensions:
-            return np.expand_dims(X, axis=self.axis)
+            return np.expand_dims(X, axis=self._axis)
         else:
             return X
 
@@ -46,7 +46,7 @@ class Reduce(BaseEstimator, TransformerMixin):
         X = np.asarray(X)
         if X.ndim < 3:
             return X
-        return np.squeeze(X, axis=self.axis)
+        return np.squeeze(X, axis=self._axis)
 
     def fit_transform(self, X, y=None):
         return self.fit(X).transform(X)

--- a/timeflux/nodes/hdf5.py
+++ b/timeflux/nodes/hdf5.py
@@ -18,7 +18,7 @@ warnings.simplefilter("ignore", NaturalNameWarning)
 class Replay(Node):
     """Replay a HDF5 file."""
 
-    def __init__(self, filename, keys, speed=1, timespan=None, resync=True, start=0):
+    def __init__(self, filename, keys, speed=1, timespan=None, resync=True, start=0,verbose=False):
         """
         Initialize.
 
@@ -41,6 +41,9 @@ class Replay(Node):
         start: float
             Start directly at the given time offset, in seconds
             Default: 0
+        verbose: boolean
+            If True, log the file being read
+            Default: False
         """
 
         # Load store
@@ -48,6 +51,9 @@ class Replay(Node):
             self._store = pd.HDFStore(self._find_path(filename), mode="r")
         except IOError as e:
             raise WorkerInterrupt(e)
+        
+        if verbose:
+            self.logger.debug("Reading from %s", filename)
 
         # Init
         self._sources = {}

--- a/timeflux/nodes/ml.py
+++ b/timeflux/nodes/ml.py
@@ -6,7 +6,8 @@ import pandas as pd
 import json
 from joblib import load
 from jsonschema import validate
-from sklearn.pipeline import make_pipeline
+from sklearn.pipeline import make_pipeline, Pipeline
+from sklearn.model_selection import cross_val_score
 from timeflux.core.node import Node
 from timeflux.core.exceptions import ValidationError, WorkerInterrupt
 from timeflux.helpers.background import Task
@@ -19,6 +20,46 @@ ACCUMULATING = 1
 FITTING = 2
 READY = 3
 
+class PipelineCV(Pipeline):
+    """
+    A pipeline with cross-validation scoring.
+    
+    Args:
+        steps (list): List of (name, transform) tuples (implementing fit/transform) that are chained, in the order in which they are chained, with the last object an estimator.
+        memory (str|object): Used to cache the fitted transformers of the pipeline.
+        verbose (bool): If True, the time elapsed while fitting each step will be printed as it is completed.
+    Methods:
+        cv_score_fit(X, y, cv=None, scoring='accuracy', **kwargs): Perform cross-validation, store the scores and fit the model.
+    Attributes:
+        scores (array-like): The cross-validation scores.
+    
+    """
+
+    def cv_score_fit(self, X, y, cv=None, scoring='accuracy', **kwargs):
+        """
+        Perform cross-validation and return the mean score.
+
+        Args:
+            X (array-like): The feature matrix.
+            y (array-like): The target labels.
+            cv (int, cross-validation generator, or an iterable): Determines the cross-validation splitting strategy.
+            scoring (str): A string (see scikit-learn documentation) or a scorer callable object/function with signature scorer(estimator, X, y).
+            **kwargs: Additional keyword arguments to be passed to cross_val_score.
+
+        Returns:
+            float: The mean cross-validation score.
+
+        Raises:
+            ValueError: If cross-validation fails.
+        """
+        try:
+            # Shuffle the data
+            indices = np.arange(X.shape[0])
+            np.random.shuffle(indices)
+            self.scores = cross_val_score(self, X[indices], y[indices], cv=cv, scoring=scoring, **kwargs)
+            self.fit(X, y)
+        except Exception as e:
+            raise ValueError("Cross-validation failed: {}".format(e))
 
 class Pipeline(Node):
     """Fit, transform and predict.
@@ -26,7 +67,7 @@ class Pipeline(Node):
     Training on continuous data is always unsupervised.
     Training on epoched data can either be supervised or unsupervised.
 
-    If fit is `False`, input events are ignored, and initital training is not performed.
+    If fit is `False`, input events are ignored, and initial training is not performed.
     Automatically set to False if mode is either 'fit_predict' or 'fit_transform'.
     Automatically set to True if mode is either 'predict', 'predict_proba' or 'predict_log_proba'.
 
@@ -41,24 +82,27 @@ class Pipeline(Node):
         o_events (Port): Event output, provides DataFrame.
 
     Args:
-        steps (dict): Pipeline steps and settings (ignored if 'model' is set)
-        fit (bool):
-        mode ('predict'|'predict_proba'|'predict_log_proba'|'transform'|'fit_predict'|'fit_transform'):
-        meta_label (str|tuple|None):
-        event_start_accumulation (str):
-        event_stop_accumulation (str):
-        event_start_training (str):
-        event_reset (str):
-        buffer_size (str):
-        passthrough (bool):
-        resample (bool):
-        resample_direction ('right'|'left'|'both'):
-        resample_rate (None|float):
-        preprocessing: A list of preprocessing steps
-        warmup (str): Load a .npy or .npz file and bootstrap the model with initial data
-        model (str): Load a pre-computed model, persisted with joblib
-        persist (str): Save the model - NOT IMPLEMENTED
-        cv: Cross-validation - NOT IMPLEMENTED
+        steps (list): List of dictionaries, each containing the keys 'module', 'class' and 'args'.
+        fit (bool): Whether to fit the model.
+        mode (str): The mode of operation: 'fit', 'predict', 'predict_proba', 'predict_log_proba', 'transform', 'fit_predict', 'fit_transform'.
+        meta_label (tuple): The keys to use for the epoch label.
+        event_start_accumulation (str): The event marking the start of accumulation.
+        event_stop_accumulation (str): The event marking the stop of accumulation.
+        event_start_training (str): The event marking the start of training.
+        event_reset (str): The event marking the reset of the model.
+        buffer_size (str): The buffer size to accumulate data before starting training.
+        passthrough (bool): Whether to pass input data to the output.
+        resample (bool): Whether to resample the output.
+        resample_direction (str): The direction to resample.
+        resample_rate (float): The resampling rate.
+        preprocessing (list): List of dictionaries, each containing the keys 'module', 'class' and 'args'.
+        warmup (str): The path to a warmup file.
+        model (str): The path to a model file.
+        persist (str): The path to save the model.
+        memory (str): Used to cache the fitted transformers of the pipeline.
+        verbose (bool): If True, the time elapsed while fitting each step will be printed as it is completed.
+        cv (int, cross-validation generator, or an iterable): Determines the cross-validation splitting strategy. Choose an int for number of fold.
+        scoring (str): A string (see scikit-learn documentation) or a scorer callable object/function with signature scorer(estimator, X, y).
 
     """
 
@@ -81,7 +125,10 @@ class Pipeline(Node):
         warmup=None,
         model=None,
         persist=None,
+        memory=None,
+        verbose=False,
         cv=None,
+        scoring="accuracy",
     ):
         # TODO: validation
         # TODO: save model to file
@@ -100,11 +147,13 @@ class Pipeline(Node):
         self.resample_rate = resample_rate
         self.warmup = warmup
         self.model = model
+        self.cv = cv
         self._buffer_size = pd.Timedelta(buffer_size)
+        self.scoring = scoring
         if model:
             self._load_pipeline(model)
         elif steps:
-            self._make_pipeline(steps)
+            self._make_pipeline(steps, memory, verbose)
         else:
             raise ValueError("You must pass either a 'steps' or 'model' argument")
         self._make_preprocessing(preprocessing)
@@ -164,9 +213,14 @@ class Pipeline(Node):
                 self.logger.debug("Start training")
                 self._warmup()
                 self._run_preprocessing()
-                self._task = Task(
-                    self._pipeline, "fit", self._X_train, self._y_train
-                ).start()
+                if self.cv is not None:
+                    self._task = Task(
+                        self._pipeline, "cv_score_fit", self._X_train, self._y_train, cv=self.cv, scoring=self.scoring
+                    ).start()
+                else:
+                    self._task = Task(
+                        self._pipeline, "fit", self._X_train, self._y_train
+                    ).start()
 
         # Is the model ready?
         if self._status == FITTING:
@@ -176,6 +230,8 @@ class Pipeline(Node):
                     self._pipeline = status["instance"]
                     self._status = READY
                     self.logger.debug(f"Model fitted in {status['time']} seconds")
+                    self._score = self._pipeline.scores
+                    self.logger.debug(f"Cross-validation score: {self._score.mean()} +/- {self._score.std()}")
                     self.o_events.data = make_event("ready")
                 else:
                     self.logger.error(
@@ -214,6 +270,7 @@ class Pipeline(Node):
         self._dimensions = None
         self._shape = ()
         self._task = None
+        self._score = None
         if self.mode.startswith("fit"):
             self.fit = False
         elif self.mode.startswith("predict"):
@@ -272,10 +329,9 @@ class Pipeline(Node):
                 )
         return pipeline
 
-    def _make_pipeline(self, steps):
-        # TODO: memory and verbose args
+    def _make_pipeline(self, steps, memory=None, verbose=False):
         pipeline = self._instantiate_pipeline(steps)
-        self._pipeline = make_pipeline(*pipeline, memory=None, verbose=False)
+        self._pipeline = PipelineCV((make_pipeline(*pipeline, memory=memory, verbose=verbose)).steps)
 
     def _load_pipeline(self, path):
         try:


### PR DESCRIPTION
1. **Modified correspondance between estimator's parameters and arguments** to match sklearn documentation on estimators "In addition, every keyword argument accepted by __init__ should correspond to an attribute on the instance. Scikit-learn relies on this to find the relevant attributes to set on an estimator when doing model selection." --> [Documentation](https://scikit-learn.org/stable/developers/develop.html)

2. **Added cross validation metrics support**, adding a cross_val_score before fitting the model if cv argument is given to ml node : 
 Classification pipeline now have an argument **cv** used for crossvalidation and set to None if you don't want to apply any metrics. The argument "scoring" is used to give details on the metrics to use following sklearn `cross_val_score` doc ([here](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_val_score.html#sklearn.model_selection.cross_val_score))
It provides a feedback in the terminal.