### PR TITLE
nodes/xarray: fixed a missing init

### DIFF
--- a/timeflux/nodes/xarray.py
+++ b/timeflux/nodes/xarray.py
@@ -51,7 +51,8 @@ class ToDataFrame(Node):
     def __init__(self, index_dim="time"):
         self._index_dim = index_dim
         self._indexes = None
-
+        self._indexes_to_unstack = None
+        
     def _set_indexes(self, data):
         self._indexes_to_unstack = [
             index for index in list(data.indexes.keys()) if index != self._index_dim


### PR DESCRIPTION
I had problems with using the nodes ToDataFrame and I was able to fix it with an init for the varibale salf.indexes_to_unstack .